### PR TITLE
Tracking-Integration decoupling

### DIFF
--- a/se_apps/src/benchmark.cpp
+++ b/se_apps/src/benchmark.cpp
@@ -114,13 +114,15 @@ int main(int argc, char ** argv) {
 
     while (reader->readNextDepthFrame(inputDepth)) {
 
+		bool tracked, integrated, raycasted;
+
 		timings[1] = std::chrono::steady_clock::now();
 
 		pipeline.preprocessing(inputDepth, inputSize, config.bilateralFilter);
 
 		timings[2] = std::chrono::steady_clock::now();
 
-		bool tracked = pipeline.tracking(camera, config.icp_threshold,
+		tracked = pipeline.tracking(camera, config.icp_threshold,
 				config.tracking_rate, frame);
 
 
@@ -133,12 +135,18 @@ int main(int argc, char ** argv) {
 		float zt = pose.data[2].w - init_pose.z;
 
 
-		bool integrated = pipeline.integration(camera, config.integration_rate,
-				config.mu, frame);
+		// Integrate only if tracking was successful or it is one of the first
+		// 4 frames.
+		if (tracked || (frame <= 3)) {
+			integrated = pipeline.integration(camera, config.integration_rate,
+					config.mu, frame);
+		} else {
+			integrated = false;
+		}
 
 		timings[4] = std::chrono::steady_clock::now();
 
-		bool raycast = pipeline.raycasting(camera, config.mu, frame);
+		raycasted = pipeline.raycasting(camera, config.mu, frame);
 
 		timings[5] = std::chrono::steady_clock::now();
 

--- a/se_apps/src/mainQt.cpp
+++ b/se_apps/src/mainQt.cpp
@@ -240,8 +240,14 @@ int processAll(DepthReader *reader, bool processFrame, bool renderImages,
 
 		timings[3] = std::chrono::steady_clock::now();
 
-		integrated = pipeline->integration(camera, config->integration_rate,
-				config->mu, frame);
+		// Integrate only if tracking was successful or it is one of the first
+		// 4 frames.
+		if (tracked || (frame <= 3)) {
+			integrated = pipeline->integration(camera,
+					config->integration_rate, config->mu, frame);
+		} else {
+			integrated = false;
+		}
 
 		timings[4] = std::chrono::steady_clock::now();
 

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -220,10 +220,7 @@ bool DenseSLAMSystem::raycasting(float4 k, float mu, uint frame) {
 bool DenseSLAMSystem::integration(float4 k, uint integration_rate, float mu,
 		uint frame) {
 
-	bool doIntegrate = poses.empty() ? checkPoseKernel(pose_, old_pose_, 
-      reduction_output_.data(), computation_size_, track_threshold) : true;
-
-  if ((doIntegrate && ((frame % integration_rate) == 0)) || (frame <= 3)) {
+  if (((frame % integration_rate == 0)) || (frame <= 3)) {
 
     float voxelsize =  volume_._dim/volume_._size;
     int num_vox_per_pix = volume_._dim/((se::VoxelBlock<FieldType>::side)*voxelsize);
@@ -290,12 +287,11 @@ bool DenseSLAMSystem::integration(float4 k, uint integration_rate, float mu,
     //     }, // end lambda
     //     make_int3(0, volume_._size/2, 0),
     //     make_int3(volume_._size, volume_._size/2 + 1, volume_._size), make_int3(volume_._size), f.str().c_str());
-    doIntegrate = true;
   } else {
-    doIntegrate = false;
+    return false;
   }
 
-	return doIntegrate;
+  return true;
 
 }
 

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -220,7 +220,7 @@ bool DenseSLAMSystem::raycasting(float4 k, float mu, uint frame) {
 bool DenseSLAMSystem::integration(float4 k, uint integration_rate, float mu,
 		uint frame) {
 
-  if (((frame % integration_rate == 0)) || (frame <= 3)) {
+  if (!poses.empty() || ((frame % integration_rate == 0)) || (frame <= 3)) {
 
     float voxelsize =  volume_._dim/volume_._size;
     int num_vox_per_pix = volume_._dim/((se::VoxelBlock<FieldType>::side)*voxelsize);


### PR DESCRIPTION
Integration must be performed if tracking was successful, if it is one of the first 4 frames or when the `poses` vector is not empty (this will be removed in the future).
- The test whether tracking was successful is now performed outside the the `integration` function. This allows decoupling of tracking and integration.
- The test about the `poses` vector remains inside the `integration` function but will be removed once `poses` is removed.
- The test about the frame number is now performed both inside and outside `integration` (it was only performed inside previously). It needs to be performed at the same place as the tracking test because tracking fails for the first few frames but integration must be performed anyway. I left the frame number test inside `integration` in case there is some use case for that I didn't think of. If it is deemed unnecessary I will remove it before the pull request is merged.