### PR TITLE
Changed ambiguous member variable name

### DIFF
--- a/se_denseslam/include/se/continuous/volume_template.hpp
+++ b/se_denseslam/include/se/continuous/volume_template.hpp
@@ -1,5 +1,5 @@
 /*
- Copyright 2016 Emanuele Vespa, Imperial College London 
+ Copyright 2016 Emanuele Vespa, Imperial College London
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -24,7 +24,7 @@
  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef VOLUME_TEMPLATE_H
 #define VOLUME_TEMPLATE_H
@@ -43,10 +43,10 @@ class Void {};
 
 /**
  * Continuous volume abstraction
- * Sparse, dynamically allocated storage accessed through the 
+ * Sparse, dynamically allocated storage accessed through the
  * appropriate indexer (octree/hash table).
- * */ 
-template <typename FieldType, template<typename> class DiscreteMapT> 
+ * */
+template <typename FieldType, template<typename> class DiscreteMapT>
 class VolumeTemplate {
 
   public:
@@ -55,30 +55,30 @@ class VolumeTemplate {
     typedef FieldType field_type;
 
     VolumeTemplate(){};
-    VolumeTemplate(unsigned int s, float d, DiscreteMapT<FieldType>* m) :
+    VolumeTemplate(unsigned int r, float d, DiscreteMapT<FieldType>* m) :
       _map_index(m) {
-        _size = s;
+        _resol = r;
         _dim = d;
       };
 
     inline Eigen::Vector3f pos(const Eigen::Vector3i & p) const {
-      static const float voxelSize = _dim/_size;
+      static const float voxelSize = _dim/_resol;
       return p.cast<float>() * voxelSize;
     }
 
     void set(const  Eigen::Vector3f& , const value_type& ) {}
 
     value_type operator[](const Eigen::Vector3f& p) const {
-      const float inverseVoxelSize = _size/_dim;
+      const float inverseVoxelSize = _resol/_dim;
       const Eigen::Vector3i scaled_pos = (p * inverseVoxelSize).cast<int>();
       return _map_index->get(scaled_pos.x(), scaled_pos.y(), scaled_pos.z());
     }
 
     value_type get(const Eigen::Vector3f & p) const {
-      const float inverseVoxelSize = _size/_dim;
+      const float inverseVoxelSize = _resol/_dim;
       const Eigen::Vector4i scaled_pos = (inverseVoxelSize * p.homogeneous()).cast<int>();
-        return _map_index->get_fine(scaled_pos.x(), 
-                                    scaled_pos.y(), 
+        return _map_index->get_fine(scaled_pos.x(),
+                                    scaled_pos.y(),
                                     scaled_pos.z());
     }
 
@@ -88,7 +88,7 @@ class VolumeTemplate {
 
     template <typename FieldSelector>
     float interp(const Eigen::Vector3f& pos, FieldSelector select) const {
-      const float inverseVoxelSize = _size / _dim;
+      const float inverseVoxelSize = _resol / _dim;
       Eigen::Vector3f discrete_pos = inverseVoxelSize * pos;
       return _map_index->interp(discrete_pos, select);
     }
@@ -96,20 +96,20 @@ class VolumeTemplate {
     template <typename FieldSelector>
     Eigen::Vector3f grad(const Eigen::Vector3f& pos, FieldSelector select) const {
 
-      const float inverseVoxelSize = _size / _dim;
+      const float inverseVoxelSize = _resol / _dim;
       Eigen::Vector3f discrete_pos = inverseVoxelSize * pos;
       return _map_index->grad(discrete_pos, select);
     }
 
-    unsigned int _size;
+    unsigned int _resol;
     float _dim;
     std::vector<se::key_t> _allocationList;
-    DiscreteMapT<FieldType> * _map_index; 
+    DiscreteMapT<FieldType> * _map_index;
 
   private:
 
     inline Eigen::Vector3i pos(const Eigen::Vector3f & p) const {
-      static const float inverseVoxelSize = _size/_dim;
+      static const float inverseVoxelSize = _resol/_dim;
       return (inverseVoxelSize * p).cast<int>();
     }
 };

--- a/se_denseslam/include/se/continuous/volume_template.hpp
+++ b/se_denseslam/include/se/continuous/volume_template.hpp
@@ -57,25 +57,25 @@ class VolumeTemplate {
     VolumeTemplate(){};
     VolumeTemplate(unsigned int r, float d, DiscreteMapT<FieldType>* m) :
       _map_index(m) {
-        _resol = r;
-        _dim = d;
+        _size = r;
+        _extent = d;
       };
 
     inline Eigen::Vector3f pos(const Eigen::Vector3i & p) const {
-      static const float voxelSize = _dim/_resol;
+      static const float voxelSize = _extent/_size;
       return p.cast<float>() * voxelSize;
     }
 
     void set(const  Eigen::Vector3f& , const value_type& ) {}
 
     value_type operator[](const Eigen::Vector3f& p) const {
-      const float inverseVoxelSize = _resol/_dim;
+      const float inverseVoxelSize = _size/_extent;
       const Eigen::Vector3i scaled_pos = (p * inverseVoxelSize).cast<int>();
       return _map_index->get(scaled_pos.x(), scaled_pos.y(), scaled_pos.z());
     }
 
     value_type get(const Eigen::Vector3f & p) const {
-      const float inverseVoxelSize = _resol/_dim;
+      const float inverseVoxelSize = _size/_extent;
       const Eigen::Vector4i scaled_pos = (inverseVoxelSize * p.homogeneous()).cast<int>();
         return _map_index->get_fine(scaled_pos.x(),
                                     scaled_pos.y(),
@@ -88,7 +88,7 @@ class VolumeTemplate {
 
     template <typename FieldSelector>
     float interp(const Eigen::Vector3f& pos, FieldSelector select) const {
-      const float inverseVoxelSize = _resol / _dim;
+      const float inverseVoxelSize = _size / _extent;
       Eigen::Vector3f discrete_pos = inverseVoxelSize * pos;
       return _map_index->interp(discrete_pos, select);
     }
@@ -96,20 +96,20 @@ class VolumeTemplate {
     template <typename FieldSelector>
     Eigen::Vector3f grad(const Eigen::Vector3f& pos, FieldSelector select) const {
 
-      const float inverseVoxelSize = _resol / _dim;
+      const float inverseVoxelSize = _size / _extent;
       Eigen::Vector3f discrete_pos = inverseVoxelSize * pos;
       return _map_index->grad(discrete_pos, select);
     }
 
-    unsigned int _resol;
-    float _dim;
+    unsigned int _size;
+    float _extent;
     std::vector<se::key_t> _allocationList;
     DiscreteMapT<FieldType> * _map_index;
 
   private:
 
     inline Eigen::Vector3i pos(const Eigen::Vector3f & p) const {
-      static const float inverseVoxelSize = _resol/_dim;
+      static const float inverseVoxelSize = _size/_extent;
       return (inverseVoxelSize * p).cast<int>();
     }
 };

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -207,8 +207,8 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
 
   if (((frame % integration_rate) == 0) || (frame <= 3)) {
 
-    float voxelsize =  volume_._dim/volume_._resol;
-    int num_vox_per_pix = volume_._dim/((se::VoxelBlock<FieldType>::side)*voxelsize);
+    float voxelsize =  volume_._extent/volume_._size;
+    int num_vox_per_pix = volume_._extent/((se::VoxelBlock<FieldType>::side)*voxelsize);
     size_t total = num_vox_per_pix * computation_size_.x() *
       computation_size_.y();
     allocation_list_.reserve(total);
@@ -218,7 +218,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
      allocated  = buildAllocationList(allocation_list_.data(),
          allocation_list_.capacity(),
         *volume_._map_index, pose_, getCameraMatrix(k), float_depth_.data(),
-        computation_size_, volume_._resol,
+        computation_size_, volume_._size,
       voxelsize, 2*mu);
     } else if(std::is_same<FieldType, OFusion>::value) {
      allocated = buildOctantList(allocation_list_.data(), allocation_list_.capacity(),
@@ -255,8 +255,8 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
     //   std::stringstream f;
     //   f << "./slices/integration_" << frame << ".vtk";
     //   save3DSlice(*volume_._map_index, Eigen::Vector3i(0, 200, 0),
-    //       Eigen::Vector3i(volume_._resol, 201, volume_._resol),
-    //       Eigen::Vector3i::Constant(volume_._resol), f.str().c_str());
+    //       Eigen::Vector3i(volume_._size, 201, volume_._size),
+    //       Eigen::Vector3i::Constant(volume_._size), f.str().c_str());
     //   f.str("");
     //   f.clear();
     // }

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -207,7 +207,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
 
   if (((frame % integration_rate) == 0) || (frame <= 3)) {
 
-    float voxelsize =  volume_._dim/volume_._size;
+    float voxelsize =  volume_._dim/volume_._resol;
     int num_vox_per_pix = volume_._dim/((se::VoxelBlock<FieldType>::side)*voxelsize);
     size_t total = num_vox_per_pix * computation_size_.x() *
       computation_size_.y();
@@ -218,7 +218,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
      allocated  = buildAllocationList(allocation_list_.data(),
          allocation_list_.capacity(),
         *volume_._map_index, pose_, getCameraMatrix(k), float_depth_.data(),
-        computation_size_, volume_._size,
+        computation_size_, volume_._resol,
       voxelsize, 2*mu);
     } else if(std::is_same<FieldType, OFusion>::value) {
      allocated = buildOctantList(allocation_list_.data(), allocation_list_.capacity(),
@@ -241,7 +241,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
 
       float timestamp = (1.f/30.f)*frame;
       struct bfusion_update funct(float_depth_.data(),
-          Eigen::Vector2i(computation_size_.x(), computation_size_.y()), 
+          Eigen::Vector2i(computation_size_.x(), computation_size_.y()),
           mu, timestamp, voxelsize);
 
       se::functor::projective_map(*volume_._map_index,
@@ -255,8 +255,8 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f& k, unsigned int integra
     //   std::stringstream f;
     //   f << "./slices/integration_" << frame << ".vtk";
     //   save3DSlice(*volume_._map_index, Eigen::Vector3i(0, 200, 0),
-    //       Eigen::Vector3i(volume_._size, 201, volume_._size),
-    //       Eigen::Vector3i::Constant(volume_._size), f.str().c_str());
+    //       Eigen::Vector3i(volume_._resol, 201, volume_._resol),
+    //       Eigen::Vector3i::Constant(volume_._resol), f.str().c_str());
     //   f.str("");
     //   f.clear();
     // }


### PR DESCRIPTION
The name _size can be ambiguous (is it the volume dimensions or its resolution?). I think _resol more clearly describes the variable purpose.

(Some trailing spaces were also removed by my text editor)