### PR TITLE
Fixed Eigen pass by value

### DIFF
--- a/se_denseslam/include/se/continuous/volume_template.hpp
+++ b/se_denseslam/include/se/continuous/volume_template.hpp
@@ -61,7 +61,7 @@ class VolumeTemplate {
         _extent = d;
       };
 
-    inline Eigen::Vector3f pos(const Eigen::Vector3i & p) const {
+    inline Eigen::Vector3f pos(const Eigen::Vector3i& p) const {
       static const float voxelSize = _extent/_size;
       return p.cast<float>() * voxelSize;
     }
@@ -74,7 +74,7 @@ class VolumeTemplate {
       return _map_index->get(scaled_pos.x(), scaled_pos.y(), scaled_pos.z());
     }
 
-    value_type get(const Eigen::Vector3f & p) const {
+    value_type get(const Eigen::Vector3f& p) const {
       const float inverseVoxelSize = _size/_extent;
       const Eigen::Vector4i scaled_pos = (inverseVoxelSize * p.homogeneous()).cast<int>();
         return _map_index->get_fine(scaled_pos.x(),
@@ -82,7 +82,7 @@ class VolumeTemplate {
                                     scaled_pos.z());
     }
 
-    value_type operator[](const Eigen::Vector3f p) const {
+    value_type operator[](const Eigen::Vector3f& p) const {
       return _map_index->get(p.x(), p.y(), p.z());
     }
 
@@ -108,7 +108,7 @@ class VolumeTemplate {
 
   private:
 
-    inline Eigen::Vector3i pos(const Eigen::Vector3f & p) const {
+    inline Eigen::Vector3i pos(const Eigen::Vector3f& p) const {
       static const float inverseVoxelSize = _size/_extent;
       return (inverseVoxelSize * p).cast<int>();
     }

--- a/se_denseslam/include/se/continuous/volume_template.hpp
+++ b/se_denseslam/include/se/continuous/volume_template.hpp
@@ -82,7 +82,7 @@ class VolumeTemplate {
                                     scaled_pos.z());
     }
 
-    value_type operator[](const Eigen::Vector3f& p) const {
+    value_type operator[](const Eigen::Vector3i& p) const {
       return _map_index->get(p.x(), p.y(), p.z());
     }
 

--- a/se_denseslam/include/se/vtk-io.h
+++ b/se_denseslam/include/se/vtk-io.h
@@ -38,7 +38,7 @@
 
 template <typename T>
 void savePointCloud(const T* in, const int num_points, 
-    const char* filename, const Eigen::Vector3f init_pose){
+    const char* filename, const Eigen::Vector3f& init_pose){
   std::stringstream points;
 
   for(int i = 0; i < num_points; ++i ){
@@ -112,9 +112,9 @@ void savePointCloud(const T* in, const int num_points,
 // } 
 
 template <typename MapType>
-void save3DSlice(const MapType& in, const Eigen::Vector3i lower, 
-    const Eigen::Vector3i upper, 
-    const Eigen::Vector3i, const char* filename){
+void save3DSlice(const MapType& in, const Eigen::Vector3i& lower, 
+    const Eigen::Vector3i& upper, 
+    const Eigen::Vector3i&, const char* filename){
   std::stringstream x_coordinates, y_coordinates, z_coordinates, scalars;
   std::ofstream f;
   f.open(filename);
@@ -160,9 +160,9 @@ void save3DSlice(const MapType& in, const Eigen::Vector3i lower,
 } 
 
 template <typename MapType, typename MapOp>
-void save3DSlice(const MapType& in, MapOp op, const Eigen::Vector3i lower, 
-    const Eigen::Vector3i upper, 
-    const Eigen::Vector3i, const char* filename){
+void save3DSlice(const MapType& in, MapOp op, const Eigen::Vector3i& lower, 
+    const Eigen::Vector3i& upper, 
+    const Eigen::Vector3i&, const char* filename){
   std::stringstream x_coordinates, y_coordinates, z_coordinates, scalars;
   std::ofstream f;
   f.open(filename);
@@ -208,7 +208,7 @@ void save3DSlice(const MapType& in, MapOp op, const Eigen::Vector3i lower,
 } 
 
 template <typename BlockList>
-void saveBlockList(const BlockList& in, const Eigen::Vector3i shift, const char* filename){
+void saveBlockList(const BlockList& in, const Eigen::Vector3i& shift, const char* filename){
 
   std::stringstream x_coordinates, y_coordinates, z_coordinates, scalars;
   std::ofstream f;
@@ -277,7 +277,7 @@ void saveBlockList(const BlockList& in, const Eigen::Vector3i shift, const char*
   f.close();
 } 
 
-void printNormals(const se::Image<Eigen::Vector3f> in, const unsigned int xdim, 
+void printNormals(const se::Image<Eigen::Vector3f>& in, const unsigned int xdim, 
                  const unsigned int ydim, const char* filename) {
   unsigned char* image = new unsigned char [xdim * ydim * 4];
   for(unsigned int y = 0; y < ydim; ++y)

--- a/se_denseslam/src/preprocessing.cpp
+++ b/se_denseslam/src/preprocessing.cpp
@@ -90,7 +90,7 @@ void bilateralFilterKernel(se::Image<float>& out, const se::Image<float>& in,
 
   void depth2vertexKernel(se::Image<Eigen::Vector3f>& vertex, 
                          const se::Image<float>& depth,
-                         const Eigen::Matrix4f invK) {
+                         const Eigen::Matrix4f& invK) {
 	TICK();
 	int x, y;
 #pragma omp parallel for \

--- a/se_denseslam/src/rendering.cpp
+++ b/se_denseslam/src/rendering.cpp
@@ -215,14 +215,14 @@ template <typename T>
 void renderVolumeKernel(const Volume<T>& volume, 
     unsigned char* out, // RGBW packed
     const Eigen::Vector2i& depthSize, 
-    const Eigen::Matrix4f view, 
+    const Eigen::Matrix4f& view, 
     const float nearPlane, 
     const float farPlane, 
     const float mu,
 		const float step, 
     const float largestep, 
-    const Eigen::Vector3f light,
-		const Eigen::Vector3f ambient, 
+    const Eigen::Vector3f& light,
+		const Eigen::Vector3f& ambient, 
     bool render, 
     const se::Image<Eigen::Vector3f>& vertex, 
     const se::Image<Eigen::Vector3f>& normal) {

--- a/se_denseslam/src/tracking.cpp
+++ b/se_denseslam/src/tracking.cpp
@@ -202,8 +202,8 @@ void new_reduce(int blockIndex, float * out, TrackData* J,
 	sums[31] = sums31;
 
 }
-void reduceKernel(float * out, TrackData* J, const Eigen::Vector2i Jsize,
-		const Eigen::Vector2i size) {
+void reduceKernel(float * out, TrackData* J, const Eigen::Vector2i& Jsize,
+		const Eigen::Vector2i& size) {
 	TICK();
 	int blockIndex;
 #ifdef OLDREDUCE
@@ -301,7 +301,7 @@ void trackKernel(TrackData* output,
 	TOCK("trackKernel", inSize.x * inSize.y);
 }
 
-bool updatePoseKernel(Eigen::Matrix4f & pose, const float * output,
+bool updatePoseKernel(Eigen::Matrix4f& pose, const float * output,
 		float icp_threshold) {
 	bool res = false;
 	TICK();
@@ -317,7 +317,7 @@ bool updatePoseKernel(Eigen::Matrix4f & pose, const float * output,
 	return res;
 }
 
-bool checkPoseKernel(Eigen::Matrix4f& pose, Eigen::Matrix4f oldPose, 
+bool checkPoseKernel(Eigen::Matrix4f& pose, Eigen::Matrix4f& oldPose, 
     const float * output, const Eigen::Vector2i& imageSize, 
     float track_threshold) {
 


### PR DESCRIPTION
Found some more instances where Eigen objects were passed by value.

Also changed the argument of `VolumeTemplate::operator[]` from Vector3f to Vector3i. Looking at `octree.hpp` it seems that the `Octree::get()` function accepts integer voxel indices from 0 to size.