### PR TITLE
Fix atomic pre-increment to post-increment in alloc list

### DIFF
--- a/se_denseslam/src/bfusion/alloc_impl.hpp
+++ b/se_denseslam/src/bfusion/alloc_impl.hpp
@@ -107,7 +107,7 @@ size_t buildOctantList(HashType* allocationList, size_t reserved,
           if(!node_ptr){
             HashType k = map_index.hash(voxel.x, voxel.y, voxel.z, 
                 std::min(tree_depth, leaves_depth));
-            unsigned int idx = ++(voxelCount);
+            unsigned int idx = voxelCount++;
             if(idx < reserved) {
               allocationList[idx] = k;
             }

--- a/se_denseslam/src/kfusion/alloc_impl.hpp
+++ b/se_denseslam/src/kfusion/alloc_impl.hpp
@@ -99,7 +99,7 @@ unsigned int buildAllocationList(HashType * allocationList, size_t reserved,
           if(!n){
             HashType k = map_index.hash(voxel.x, voxel.y, voxel.z, 
                 block_scale);
-            unsigned int idx = ++voxelCount;
+            unsigned int idx = voxelCount++;
             if(idx < reserved) {
               allocationList[idx] = k;
             } else


### PR DESCRIPTION
In the pre-increment version allocationList[0] is never set, causing seg fault when memory is highly used, changing to post-increment solves this issue. Notice std::atomic supports post-increment thought fetch_add 